### PR TITLE
Fix add element to list in zsh if the element contains an environment variable

### DIFF
--- a/multisheller/backend/zsh.py
+++ b/multisheller/backend/zsh.py
@@ -6,7 +6,7 @@ def ensure_quotes(x):
     if x[0] == '"' or x[0] == '\'' and x[-1] == x[0]:
       return x
     else:
-      return f"\"{re.escape(x)}\""
+      return f"\"{x}\""
 
 
 class BashVisitor(NodeVisitor):


### PR DESCRIPTION
In particular, avoid to escape the argument of the ensure_quotes function in zsh, as done in bash