### PR TITLE
In Git Bash for environment variables different from PATH on Windows use semicolon as list separator

### DIFF
--- a/multisheller/_version.py
+++ b/multisheller/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 3, 0)
+version_info = (0, 3, 1)
 __version__ = ".".join(map(str, version_info))

--- a/multisheller/backend/common.py
+++ b/multisheller/backend/common.py
@@ -13,17 +13,31 @@ def join_expr(expr_list, visitor):
     return indent('\n'.join(final_expr), '    ')
 
 sh_path_functions = """
+getpathlistseparator () {
+        local PATHVARIABLE=${1:-PATH}
+        # If on Windows and PATHVARIABLE is not PATH, 
+        # the list separator is ";" otherwise is ":"
+        local PATHSEP=":"
+        if [ ! -z $COMSPEC ]; then
+          if [ "$PATHVARIABLE" != "PATH" ]; then
+            local PATHSEP=";"
+          fi
+        fi
+        echo "$PATHSEP"
+}
+
 # Taken from http://www.linuxfromscratch.org/blfs/view/svn/postlfs/profile.html
 # Functions to help us manage paths.  Second argument is the name of the
 # path variable to be modified (default: PATH)
 pathremove () {
-        local IFS=':'
         local NEWPATH
         local DIR
         local PATHVARIABLE=${2:-PATH}
+        local PATHSEP=$(getpathlistseparator $PATHVARIABLE)
+        local IFS=$PATHSEP
         for DIR in ${!PATHVARIABLE} ; do
                 if [ "$DIR" != "$1" ] ; then
-                  NEWPATH=${NEWPATH:+$NEWPATH:}$DIR
+                  NEWPATH=${NEWPATH:+$NEWPATH${PATHSEP}}$DIR
                 fi
         done
         export $PATHVARIABLE="$NEWPATH"
@@ -32,13 +46,15 @@ pathremove () {
 pathprepend () {
         # pathremove $1 $2
         local PATHVARIABLE=${2:-PATH}
-        export $PATHVARIABLE="$1${!PATHVARIABLE:+:${!PATHVARIABLE}}"
+        local PATHSEP=$(getpathlistseparator $PATHVARIABLE)
+        export $PATHVARIABLE="$1${!PATHVARIABLE:+${PATHSEP}${!PATHVARIABLE}}"
 }
 
 pathappend () {
         # pathremove $1 $2
         local PATHVARIABLE=${2:-PATH}
-        export $PATHVARIABLE="${!PATHVARIABLE:+${!PATHVARIABLE}:}$1"
+        local PATHSEP=$(getpathlistseparator $PATHVARIABLE)
+        export $PATHVARIABLE="${!PATHVARIABLE:+${!PATHVARIABLE}${PATHSEP}}$1"
 }
 """
 


### PR DESCRIPTION
In Git Bash on Windows, `PATH` is a bit special environment variable as it is automatically converted to Unix-style path and it is uses `:` as list separator.
However, all other list environment variables are not modified by Git Bash, and so use the semicolon (`;`) as Windows normally does. 

This PR make sure that the `pathremove`/`pathprepend`/`pathappend` function in bash are aware of this and use the correct path list seperator depending on the environment variable and the operating system used. 